### PR TITLE
Fix iphone test

### DIFF
--- a/tests/fixtures/standard_replies/iphone.eml
+++ b/tests/fixtures/standard_replies/iphone.eml
@@ -9,7 +9,7 @@ To: bob <bob@example.com>
 Content-Transfer-Encoding: quoted-printable
 Mime-Version: 1.0 (1.0)
 
-hello
+Hello
 
 Sent from my iPhone
 

--- a/tests/fixtures/standard_replies/iphone_reply_text
+++ b/tests/fixtures/standard_replies/iphone_reply_text
@@ -1,0 +1,3 @@
+Hello
+
+Sent from my iPhone

--- a/tests/text_quotations_test.py
+++ b/tests/text_quotations_test.py
@@ -596,7 +596,7 @@ def test_standard_replies():
             reply_text_fn = filename[:-4] + '_reply_text'
             if os.path.isfile(reply_text_fn):
                 with open(reply_text_fn) as f:
-                    reply_text = f.read()
+                    reply_text = f.read().strip()
             else:
                 reply_text = 'Hello'
             yield eq_, reply_text, stripped_text, \


### PR DESCRIPTION
I'm honestly not sure how the test is passing on `mailgun:master`, but this changes the test to match the what talon is doing (correct behavior), returning the message with its signature.
